### PR TITLE
Update node_resource.rb

### DIFF
--- a/app/services/foreman_discovery/node_api/node_resource.rb
+++ b/app/services/foreman_discovery/node_api/node_resource.rb
@@ -82,7 +82,7 @@ module ForemanDiscovery::NodeAPI
     def get(payload = {}, path = nil)
       logger.debug("Image API GET #{url} (path=#{path}, payload=#{payload})")
       if path
-        resource[URI.escape(path)].get payload
+        resource[CGI.escape(path)].get payload
       else
         resource.get payload
       end


### PR DESCRIPTION
URI.escape is deprecated and fails on RHEL9

Changing to CGI.escape fixes for 
Red Hat Satellite (build: 6.16.0.1) on Red Hat Enterprise Linux release 9.5 (Plow) latest patches